### PR TITLE
32 change dev container database

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,5 +12,5 @@ RUN conda install -y python=3.10 \
     && pipx reinstall-all
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends python3-dev python3-pip default-libmysqlclient-dev build-essential

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
 FROM mcr.microsoft.com/devcontainers/miniconda:1-3
 
-# Copy environment.yml (if found) to a temp location so we update the environment. Also
-# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends python3-dev python3-pip default-libmysqlclient-dev build-essential
+
+# Copy environment.yml (if found) to a temp location so we update the environment.
 COPY .devcontainer/environment.yml* /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
@@ -11,6 +14,3 @@ RUN conda install -y python=3.10 \
     && pip install --no-cache-dir pipx \
     && pipx reinstall-all
 
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends python3-dev python3-pip default-libmysqlclient-dev build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,10 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/miniconda
 {
-	"name": "Miniconda (Python 3)",
-	"build": { 
-		"context": "..",
-		"dockerfile": "Dockerfile"
-	},
+	"name": "reviewSite",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "customizations": {
         "vscode": {
           "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     image: mysql:latest
     restart: unless-stopped
     volumes:
-      - mysql-data:/var/lib/mysql/data
+      - mysql-data:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: supersecret
       MYSQL_DATABASE: reviewSite

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,11 +3,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    environment:
-      MYSQL_ROOT_PASSWORD: supersecret
-      MYSQL_DATABASE: reviewSite
-      MYSQL_USER: mysql
-      MYSQL_PASSWORD: mysql
+    env_file:
+      - .env
 
     volumes:
       - ../..:/workspaces:cached
@@ -26,11 +23,8 @@ services:
     restart: unless-stopped
     volumes:
       - mysql-data:/var/lib/mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: supersecret
-      MYSQL_DATABASE: reviewSite
-      MYSQL_USER: mysql
-      MYSQL_PASSWORD: mysql
+    env_file:
+      - .env
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST: localhost
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST: localhost
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: supersecret
       MYSQL_DATABASE: reviewSite
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
 
     volumes:
       - ../..:/workspaces:cached
@@ -27,6 +29,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: supersecret
       MYSQL_DATABASE: reviewSite
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,10 +4,8 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST: localhost
+      MYSQL_ROOT_PASSWORD: supersecret
+      MYSQL_DATABASE: reviewSite
 
     volumes:
       - ../..:/workspaces:cached
@@ -22,18 +20,16 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: postgres:latest
+    image: mysql:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - mysql-data:/var/lib/mysql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST: localhost
+      MYSQL_ROOT_PASSWORD: supersecret
+      MYSQL_DATABASE: reviewSite
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:
-  postgres-data:
+  mysql-data:

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -12,6 +12,7 @@ dependencies:
       - django==5.1
       - django-crispy-forms==2.1
       - idna==3.7
+      - mysqlclient==2.2.4
       - pillow==10.3.0
       - python-dotenv==1.0.1
       - redis==5.0.4

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
-reviewSite\superuser.txt
-reviewSite\media
-reviewSite\db.sqlite3
+# Ignore media files
+media/
+
+# Ignore cache files
+__pycache__/
 *.pyc
-reviewSite/db.sqlite3
-reviewSite/.env
+
+# Ignore vscode settings
 .vscode
+
+# Ignore environment variables
+.env

--- a/reviewSite/reviewSite/settings.py
+++ b/reviewSite/reviewSite/settings.py
@@ -83,8 +83,12 @@ WSGI_APPLICATION = 'reviewSite.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'reviewSite',
+        'USER': 'mysql',
+        'PASSWORD': 'mysql',
+        'HOST': '127.0.0.1',
+        'PORT': '3306',
     }
 }
 


### PR DESCRIPTION
Hola, als het goed is doet de database het nu. 
Je moet zelf alleen nog een .env file in de .devcontainer folder zetten, met de variabelen die in de settings.py staan voor:

MYSQL_ROOT_PASSWORD=
MYSQL_DATABASE=
MYSQL_USER=
MYSQL_PASSWORD=

root_password is variable, maar de rest moet overeenkomen met de name user en password in de setting.py